### PR TITLE
navigation fixes

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -1,6 +1,7 @@
 class BookingsController < ApplicationController
- before_action :set_life
+  before_action :set_life, except: [:index]
   before_action :set_booking, only: [:show, :edit, :update, :destroy]
+
   def index
     @bookings = Booking.where(user_id: current_user.id)
   end
@@ -10,6 +11,8 @@ class BookingsController < ApplicationController
   end
 
   def show
+    # Don't override @life if it's already set by set_life
+    @booking = @life.bookings.find(params[:id])
   end
 
   def create
@@ -46,7 +49,8 @@ class BookingsController < ApplicationController
   end
 
   private
-def set_life
+
+  def set_life
     @life = Life.find(params[:life_id])
   end
 

--- a/app/controllers/lives_controller.rb
+++ b/app/controllers/lives_controller.rb
@@ -18,10 +18,9 @@ class LivesController < ApplicationController
     @life = Life.new(life_params)
     @life.user = current_user
     if @life.save
-      # Set current_user as host if not already
+      redirect_to life_path(@life), notice: "Life created successfully."
       unless current_user.is_host
       current_user.update(is_host: true)
-      redirect_to life_path(@life)
       end
     else
       render :new, status: :unprocessable_entity
@@ -32,14 +31,14 @@ class LivesController < ApplicationController
     @life = Life.find(params[:id])
   end
 
-def update
-  @life = Life.find(params[:id])
-  if @life.update(life_params)
-    redirect_to life_path(@life), notice: "Life updated successfully."
-  else
-    render :edit, status: :unprocessable_entity
+  def update
+    @life = Life.find(params[:id])
+    if @life.update(life_params)
+      redirect_to life_path(@life), notice: "Life updated successfully."
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
-end
 
   def destroy
     @life = Life.find(params[:id])

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,7 +2,11 @@ class PagesController < ApplicationController
   skip_before_action :authenticate_user!, only: [:home, :about]
 
   def home
-    @lives = Life.all
+    if user_signed_in?
+      @lives = Life.where.not(user_id: current_user.id)
+    else
+      @lives = Life.all
+    end
   end
 
   def about

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -15,6 +15,6 @@
     <p><%= booking.start_date %></p>
     <p><%= booking.end_date %></p>
     <p><%= "€ #{booking.total_price}" %></p>
-    <%= link_to "Show Booking", life_booking_path(booking.life.id, booking), class: "btn btn-primary mt-5" %>
+    <%= link_to "Show Booking", life_booking_path(booking.life, booking), class: "btn btn-primary mt-5" %>
   <% end %>
 </div>

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -15,6 +15,6 @@
     <p><%= booking.start_date %></p>
     <p><%= booking.end_date %></p>
     <p><%= "€ #{booking.total_price}" %></p>
-    <%= link_to "Show Booking", life_booking_path(booking.life, booking), class: "btn btn-primary mt-5" %>
+    <%= link_to "Show Booking", life_booking_path(booking.life.id, booking), class: "btn btn-primary mt-5" %>
   <% end %>
 </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,7 +1,7 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon">
   <div class="container-fluid">
-    <%= link_to "#", class: "navbar-brand" do %>
-      <%= image_tag "https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/logo.png" %>
+       <%= link_to root_path, class: "navbar-brand" do %>
+      <%= image_tag "logo.png" %>
     <% end %>
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,7 +1,7 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon">
   <div class="container-fluid">
-    <%= link_to root_path, class: "navbar-brand" do %>
-      <%= image_tag "logo.png" %>
+    <%= link_to "#", class: "navbar-brand" do %>
+      <%= image_tag "https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/logo.png" %>
     <% end %>
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -12,23 +12,20 @@
       <ul class="navbar-nav me-auto">
         <% if user_signed_in? %>
           <li class="nav-item active">
-            <%= link_to "Booked lives", life_bookings_path(current_user), class: "nav-link" %>
+            <%= link_to "Home", "/", class: "nav-link" %>
           </li>
           <li class="nav-item">
-            <%= link_to "Lives Offers", lives_path, class: "nav-link" %>
+            <%= link_to "Messages", "#", class: "nav-link" %>
           </li>
           <li class="nav-item dropdown">
           <a href="#" class="avatar" id="navbarDropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar", alt: "dropdown menu" %>
           </a>
-            <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
+          <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
+          <%= link_to "Your bookings", bookings_path, class: "dropdown-item" %>
+          <%= link_to "Create Life", new_life_path, class: "dropdown-item" %>
               <% if current_user.is_host %>
-                <%= link_to "Your details", users_show_path, class: "dropdown-item" %>
                 <%= link_to "Your lives", lives_path, class: "dropdown-item" %>
-                <%= link_to "Create Life", new_life_path, class: "dropdown-item" %>
-                <%= link_to "Your bookings", life_bookings_path(current_user.bookings), class: "dropdown-item" %>
-              <% else %>
-                <%= link_to "Your bookings", life_bookings_path(current_user.bookings), class: "dropdown-item" %>
               <% end %>
               <%= link_to "Log out", destroy_user_session_path, data: {turbo_method: :delete}, class: "dropdown-item" %>
             </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
   get "/users/:id/edit", to: "users#edit"
   patch "/users/:id", to: "users#update"
 
+  get '/bookings', to: 'bookings#index', as: 'bookings'
+  get '/bookings/:id', to: 'bookings#show', as: 'booking'
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
I changed a few bits in order to restore full functionalities and navigation for both types of user
I also made slight changes when it comes to the drop-down menu, I made it so that a normal user can gain access to host features after creating their own "life experience". 
I also change the landing page so that it visualizes all of the available "life experiences" while waiting for a user to log in, once a user is logged in, they are not able to see their own "life experiences" in the list of the bookable experience.
I fixed and clean a url that looked a bit weird by adding routes related to booking outside the nesting with lives. When it comes to a user visualizing their own booking the url should be as clean as possible "/bookings" as well as for visualizing a single booking "/bookings/:id", I felt the nesting was over-complicating this and making the url visually messy.